### PR TITLE
Flesh out the revocation guide

### DIFF
--- a/content/docs/Usage/haskell.md
+++ b/content/docs/Usage/haskell.md
@@ -100,6 +100,32 @@ sealBiscuit :: Biscuit Open c -> Biscuit Sealed c
 sealBiscuit b = seal b
 ```
 
+## Reject revoked tokens
+
+Revoked tokens can be rejected directly during parsing:
+
+```haskell
+import Auth.Biscuit
+
+parseBiscuit :: IO Bool
+parseBiscuit =  do
+  let parsingOptions = ParserConfig
+        { encoding = UrlBase64
+        , getPublicKey = \_ -> myPublicKey
+        -- ^ biscuits carry a key identifier, allowing you to choose the
+        -- public key used for signature verification. Here we ignore
+        -- it, to always use the same public key
+        , isRevoked = fromRevocationList revokedIds
+        -- ^ `fromRevocationList` takes a list of revoked ids, but
+        -- the library makes it possible to run an effectful check instead
+        -- if you don't have a static revocation list
+        }
+  result <- parseWith parsingOptions encodedBiscuit
+  case result of
+    Left _ -> False
+    Right _ -> True
+```
+
 ## Query data from the authorizer
 
 (filters)

--- a/content/docs/guides/revocation.md
+++ b/content/docs/guides/revocation.md
@@ -15,3 +15,56 @@ top = false
 +++
 
 ## Revocation identifiers
+
+Biscuit tokens are bearer tokens. Revoking bearer tokens is usually done through revocation lists: a list of
+tokens that are no longer accepted is shared with all verifying parties. When authorizing a biscuit token,
+the library will make sure the token has not been revoked.
+
+Such a mechanism relies on being able to uniquely identify tokens: we want to be able to revoke only the tokens
+that are not valid anymore, without revoking other tokens (even tokens with the same payload but have been issued
+to another holder). With offline attenuation, biscuits introduce another constraint: revoking a token should also
+revoke all derived tokens (else it would be trivial to circument revocation).
+
+The biscuit spec (and libraries) provide you with:
+
+ - a way to uniquely identify tokens (two biscuits with the same payload and secret key will be different)
+ - a way to identify groups of tokens derived from the same parent token
+ - a way to reject tokens based on their ids during authorization
+
+The biscuit spec _does not mandate_ how to publish revoked ids within your system;
+that depends a lot on the architecture and constraints of the systems.
+You can start simple with static revocation lists read through environment variables, and migrate to more complex systems as needed.
+
+### Listing revocation ids for a token
+
+The [CLI](../../Usage/cli/#verify-a-token) can be used to inspect revocation ids:
+
+```
+❯ biscuit inspect test9_expired_token.bc --raw-input
+Authority block:
+== Datalog ==
+
+== Revocation id ==
+16d0a9d7f3d29ee2112d67451c8e4ff07bd5366a6cdb082cf4fcb66e6d15a57a22009ef1018fc4d0f9184edb0900df161807bc6f8287275f32eae6b5b1c57100
+
+==========
+
+Block n°1:
+== Datalog ==
+check if resource("file1");
+check if time($date), $date <= 2018-12-20T00:00:00+00:00;
+
+== Revocation id ==
+0670d948462e0cc248ce45b7ea04cbfb126a7559c8d60b533f7f0a92696900ee4e432780b526462b845d372c9b7b223c43efc22e0441b14b0bc4661e05ebfe03
+
+==========
+
+🙈 Public key check skipped 🔑
+🙈 Datalog check skipped 🛡️
+```
+
+### Providing a revocation list during biscuit authorization
+
+#### In haskell
+
+[Rejecting revoked ids in haskell](../../Usage/haskell/#reject-revoked-tokens)


### PR DESCRIPTION
This is a bit barebones, but this explains how revocation ids work, and how to get them from the CLI. A nice addition would be links to how to actually pass revocation ids to the various libraries. I guess it'd be better to have specific examples in each `Usage` page, and put links in the revocation guide.