### PR TITLE
Use `datalog-playground` for datalog examples, with a fixed shortcode

### DIFF
--- a/templates/shortcodes/datalog.html
+++ b/templates/shortcodes/datalog.html
@@ -1,5 +1,4 @@
 <div style="text-align:left">
-<bc-datalog-example code='{{ body | safe }}'>
-  <code>{{ body | safe }}</code>
-</bc-datalog-example>
+<bc-datalog-playground code="{{ body }}">
+</bc-datalog-playground>
 </div>

--- a/wc/package-lock.json
+++ b/wc/package-lock.json
@@ -18,9 +18,9 @@
       "integrity": "sha512-wi2ncBg89nE2O4+kKH/8FY6ljaHRoPQhawLVBsAtkdwP2Co0iGF9QO13nBnvQG9DXYV6G/ewUbxW+rvQQftLtw=="
     },
     "@biscuit-auth/web-components": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@biscuit-auth/web-components/-/web-components-0.3.6.tgz",
-      "integrity": "sha512-ZAsR3N7jKL4x2Z6PcLpDKNFjCRzZ60zEhuKwMQq4TP+O5sSQbaamMB8OqDur0bpD+fnY/2U88XaGVWxUzzdYzw==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@biscuit-auth/web-components/-/web-components-0.3.7.tgz",
+      "integrity": "sha512-9WKd7atu4TGYDRX4fjQTcu3e7oFun9AZoJfWypsvOmV3lcZX0t9YQ6p4xPRhWEqHcgezQ8NJmC/ed+POFjOt2w==",
       "requires": {
         "@biscuit-auth/biscuit-wasm-support": "0.2.2",
         "@codemirror/basic-setup": "^0.19.0",

--- a/wc/package.json
+++ b/wc/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@biscuit-auth/web-components": "0.3.6"
+    "@biscuit-auth/web-components": "0.3.7"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^21.0.1",


### PR DESCRIPTION
Using the `code` attribute and default escaping works well (using `code='{{ body | safe }}'` resulted in truncated display