### PR TITLE
correct installation commands for biscuit-cli

### DIFF
--- a/content/docs/Usage/cli.md
+++ b/content/docs/Usage/cli.md
@@ -19,7 +19,9 @@ top = false
 ### From source
 
 ```
-cargo install biscuit-cli
+git clone https://github.com/biscuit-auth/biscuit-cli.git
+cd biscuit-cli
+cargo install --path .
 ```
 
 ### From pre-built packages


### PR DESCRIPTION
`biscuit-cli` has not yet been published