### PR TITLE
fix(typo)

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -52,12 +52,12 @@ user(1234);
 check if operation("read");
 
 // The authorizer loads facts representing the request
-resource("admin.txt");
+resource("admin.doc");
 operation("read");
 
 // The authorizer loads the user's rights
-right(1234, "admin.txt", "read");
-right(1234, "admin.txt", "write");
+right(1234, "admin.doc", "read");
+right(1234, "admin.doc", "write");
 
 // Finally, the authorizer tests policies
 // by looking for a set of facts matching them

--- a/content/docs/getting-started/introduction.md
+++ b/content/docs/getting-started/introduction.md
@@ -44,12 +44,12 @@ user("1234"); // the user is identified as "1234"
 check if operation("read"); // the token is restricted to read-only operations
 
 // The authorizer loads facts representing the request
-resource("admin.txt");
+resource("admin.doc");
 operation("read");
 
 // The authorizer loads the user's rights
-right("1234", "admin.txt", "read");
-right("1234", "admin.txt", "write");
+right("1234", "admin.doc", "read");
+right("1234", "admin.doc", "write");
 
 // Finally, the authorizer tests policies
 // by looking for a set of facts matching them


### PR DESCRIPTION
Comments [talks about admin.doc](https://github.com/biscuit-auth/website/compare/main...FGRibreau:biscuit-website:main#diff-200abda264c3530e9cdb5d895e25d50bc3ed567079b39fe2ee3c1d1b5d661e09R47) but datalog example talks about admin.txt, this PR fix this small typo :)