### PR TITLE
Fix Haskell usage regarding key generation

### DIFF
--- a/content/docs/Usage/haskell.md
+++ b/content/docs/Usage/haskell.md
@@ -43,7 +43,7 @@ main = do
 {-# LANGUAGE QuasiQuotes #-}
 import Auth.Biscuit
 
-myBiscuit :: SecretKey -> Biscuit
+myBiscuit :: SecretKey -> IO (Biscuit Open Verified)
 myBiscuit secretKey =
   -- datalog blocks are declared inline and are parsed
   -- at compile time

--- a/content/docs/Usage/haskell.md
+++ b/content/docs/Usage/haskell.md
@@ -29,7 +29,7 @@ import Auth.Biscuit
 
 main :: IO ()
 main = do
-  secretKey <- generateSecretKey
+  secretKey <- newSecret
   let publicKey = toPublic secretKey
   -- will print the hex-encoded secret key
   print $ serializeSecretKeyHex secretKey


### PR DESCRIPTION
`generateSecretKey` is not exported by `Auth.Biscuit`, but the alias `newSecret` is.

Maybe fixing the documentation isn't the best fix, but right now the usage guide isn't working 😬

mkBiscuit usage was also off (according to my dear compiler)