### PR TITLE
fix the "my-first-biscuit" examples

### DIFF
--- a/content/docs/getting-started/my-first-biscuit.md
+++ b/content/docs/getting-started/my-first-biscuit.md
@@ -41,9 +41,9 @@ _datalog_. Datalog is a declarative logic language that is a subset of Prolog.
 A Datalog program contains "facts", which represent data, and "rules", which can generate new facts from existing ones.
 
 In our example, we will create a token that identifies its carrier as a _user_ whose user id is `"1234"`.
-To do so, we will create a file named `authority.datalog`, with the following contents:
+To do so, we will create a file named `authority.biscuit-datalog`, with the following contents:
 
-`authority.datalog`
+`authority.biscuit-datalog`
 
 ```
 user("1234");
@@ -54,7 +54,7 @@ This is a datalog _fact_: the fact name is `user`, and it has a single attribute
 Now we have a secret key and an authority block, we can go ahead and generate a biscuit:
 
 ```
-❯ biscuit generate --private-key-file key.secret authority.datalog
+❯ biscuit generate --private-key 473b5189232f3f597b5c2f3f9b0d5e28b1ee4e7cce67ec6b7fbf5984157a6b97 authority.biscuit-datalog
 En0KEwoEMTIzNBgDIgkKBwgKEgMYgAgSJAgAEiBw-OHV3egI0IVjiC1vdB7WZ__t0FCvB2s-81PexdwuqxpAolMr9XDP7T44qgdXxtumc2P3O93pCHaGSuBUs3_f8nsQJ7NU6PdkujZIMStzEJ36CDnxawSZjUAKoTO-a1cCDSIiCiBPsG53WHcpxeydjSpFYNYnvPAeM1tVBvOEG9SQgMrzbw==
 ```
 
@@ -95,7 +95,7 @@ To do so, the service provides an authorizer, built with:
 
 In our case, we'll assume the token is used for a `write` operation on the `resource1` resource.
 
-_authorizer.datalog_
+_authorizer.biscuit-datalog_
 
 ```
 // request-specific data
@@ -143,7 +143,7 @@ a2532bf570cfed3e38aa0757c6dba67363f73bdde90876864ae054b37fdff27b1027b354e8f764ba
 Matched allow policy: allow if is_allowed($user, $resource, $op)
 ```
 
-<bc-token-printer biscuit="En0KEwoEMTIzNBgDIgkKBwgKEgMYgAgSJAgAEiBw-OHV3egI0IVjiC1vdB7WZ__t0FCvB2s-81PexdwuqxpAolMr9XDP7T44qgdXxtumc2P3O93pCHaGSuBUs3_f8nsQJ7NU6PdkujZIMStzEJ36CDnxawSZjUAKoTO-a1cCDSIiCiBPsG53WHcpxeydjSpFYNYnvPAeM1tVBvOEG9SQgMrzbw==" readonly="true" showAuthorizer="true">
+<bc-token-printer biscuit="En0KEwoEMTIzNBgDIgkKBwgKEgMYgAgSJAgAEiBw-OHV3egI0IVjiC1vdB7WZ__t0FCvB2s-81PexdwuqxpAolMr9XDP7T44qgdXxtumc2P3O93pCHaGSuBUs3_f8nsQJ7NU6PdkujZIMStzEJ36CDnxawSZjUAKoTO-a1cCDSIiCiBPsG53WHcpxeydjSpFYNYnvPAeM1tVBvOEG9SQgMrzbw==" readonly="true" rootPublicKey="41e77e842e5c952a29233992dc8ebbedd2d83291a89bb0eec34457e723a69526" showAuthorizer="true">
   <code class="authorizer">
 // request-specific data
 operation("write");
@@ -177,7 +177,7 @@ token will only be usable for a given period of time. In the authorizer above, w
 a `time` fact, that was not used in a policy or a check. We can add a block that will make
 sure the token is not used after a certain date.
 
-_block1.datalog_
+_block1.biscuit-datalog_
 
 ```
 check if time($time), $time <= 2021-12-20T00:00:00Z;
@@ -188,7 +188,7 @@ The check requires two things to suceed: first, the current time must be declare
 We can create a new token by appending this block to our existing token:
 
 ```
-❯ biscuit attenuate - --block-file 'block1.datalog'
+❯ biscuit attenuate - --block-file 'block1.biscuit-datalog'
 Please input a base64-encoded biscuit, followed by <enter> and ^D
 En0KEwoEMTIzNBgDIgkKBwgKEgMYgAgSJAgAEiBw-OHV3egI0IVjiC1vdB7WZ__t0FCvB2s-81PexdwuqxpAolMr9XDP7T44qgdXxtumc2P3O93pCHaGSuBUs3_f8nsQJ7NU6PdkujZIMStzEJ36CDnxawSZjUAKoTO-a1cCDSIiCiBPsG53WHcpxeydjSpFYNYnvPAeM1tVBvOEG9SQgMrzbw==
 En0KEwoEMTIzNBgDIgkKBwgKEgMYgAgSJAgAEiBw-OHV3egI0IVjiC1vdB7WZ__t0FCvB2s-81PexdwuqxpAolMr9XDP7T44qgdXxtumc2P3O93pCHaGSuBUs3_f8nsQJ7NU6PdkujZIMStzEJ36CDnxawSZjUAKoTO-a1cCDRqUAQoqGAMyJgokCgIIGxIGCAUSAggFGhYKBAoCCAUKCAoGIICP_40GCgQaAggCEiQIABIgkzpUMZubXcd8K7mWNchjb0D2QXeYoWtlZw2KMryKubUaQOFlx4iPKUqKeJrEH4MKO7tjM3H9z1rYbOj-gKGTtYJ4bac0kIoWl9v_7q7qN7fQJJgj0IU4jx4_QhxIk9SeigMiIgogqvHkuXrYkoMRvKgT9zNV4BEKC5W2K8L7NcGiX44ASwE=


### PR DESCRIPTION
- the canonical extension for biscuit datalog files is now biscuit-datalog
- don't use files for the private key
- pass the public key to the token inspector component