### PR TITLE
Add a link to the tooling page in the menu

### DIFF
--- a/content/docs/tooling/_index.md
+++ b/content/docs/tooling/_index.md
@@ -8,3 +8,8 @@ sort_by = "weight"
 weight = 4
 draft = false
 +++
+
+Biscuit tokens can be created, inspected and manipulated from within the browser.
+If you want to try things out quickly, they are a good addition to the command-line tool.
+
+The datalog playground allows you to evaluate datalog policies without having to craft a token.

--- a/templates/macros/header.html
+++ b/templates/macros/header.html
@@ -36,6 +36,9 @@
 				<li class="nav-item">
 					<a class="nav-link" href="{{ get_url(path="blog", trailing_slash=true) | safe }}">Blog</a>
 				</li>
+				<li class="nav-item">
+					<a class="nav-link" href="{{ get_url(path="docs/tooling/", trailing_slash=true) | safe }}">Online tooling</a>
+				</li>
 				{% endif %}
 			</ul>
 			<div class="break order-6 d-md-none"></div>


### PR DESCRIPTION
<img width="1440" alt="Capture d’écran 2023-04-11 à 10 15 47" src="https://user-images.githubusercontent.com/173299/231099697-91112ea2-e738-4bce-b26a-17659b8c365f.png">


since we're moving documentation to a dedicated domain, we'll need to make other content more easily accessible