### PR TITLE
Netlify

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,22 +45,19 @@ jobs:
       - name: Build docs
         run: |
           ./mdbook build docs
-      - uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --acl public-read --follow-symlinks --delete
-        env:
-          AWS_S3_BUCKET: ${{ secrets.CELLAR_BUCKET }}
-          AWS_S3_ENDPOINT: https://cellar-c2.services.clever-cloud.com/
-          AWS_ACCESS_KEY_ID: ${{ secrets.CELLAR_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CELLAR_KEY_SECRET }}
-          SOURCE_DIR: 'public'
-      - uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --acl public-read --follow-symlinks --delete
-        env:
-          AWS_S3_BUCKET: ${{ secrets.CELLAR_DOCS_BUCKET }}
-          AWS_S3_ENDPOINT: https://cellar-c2.services.clever-cloud.com/
-          AWS_ACCESS_KEY_ID: ${{ secrets.CELLAR_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CELLAR_KEY_SECRET }}
-          SOURCE_DIR: 'docs/book'
+      - name: Deploy biscuitsec.org to netlify
+        run: |
+          zip -r biscuitsec.zip public
+          curl -H "Content-Type: application/zip" \
+               -H "Authorization: Bearer ${{ secrets.NETLIFY_TOKEN }}" \
+               --data-binary @biscuitsec.zip \
+               https://api.netlify.com/api/v1/sites/biscuitsec.netlify.app/deploys
+      - name: Deploy doc.biscuitsec.org to netlify
+        run: |
+          zip -r doc.biscuitsec.zip docs/book
+          curl -H "Content-Type: application/zip" \
+               -H "Authorization: Bearer ${{ secrets.NETLIFY_TOKEN }}" \
+               --data-binary @doc.biscuitsec.zip \
+               https://api.netlify.com/api/v1/sites/doc-biscuitsec.netlify.app/deploys
+ 
 

--- a/content/netlify.toml
+++ b/content/netlify.toml
@@ -1,0 +1,205 @@
+
+[[redirects]]
+  force = true
+  from = "/docs/getting-started/introduction/"
+  status = 301
+  to = "https://doc.biscuitsec.org/getting-started/introduction.html"
+
+[[redirects]]
+  force = true
+  from = "docs/getting-started/introduction/index.html"
+  status = 301
+  to = "https://doc.biscuitsec.org/getting-started/introduction.html"
+
+[[redirects]]
+  force = true
+  from = "/docs/getting-started/token/"
+  status = 301
+  to = "https://doc.biscuitsec.org/getting-started/introduction.html"
+
+[[redirects]]
+  force = true
+  from = "docs/getting-started/token/index.html"
+  status = 301
+  to = "https://doc.biscuitsec.org/getting-started/introduction.html"
+
+[[redirects]]
+  force = true
+  from = "/docs/getting-started/my-first-biscuit/"
+  status = 301
+  to = "https://doc.biscuitsec.org/getting-started/my-first-biscuit.html"
+
+[[redirects]]
+  force = true
+  from = "docs/getting-started/my-first-biscuit/index.html"
+  status = 301
+  to = "https://doc.biscuitsec.org/getting-started/my-first-biscuit.html"
+
+[[redirects]]
+  force = true
+  from = "/docs/getting-started/policies/"
+  status = 301
+  to = "https://doc.biscuitsec.org/getting-started/authorization-policies.html"
+
+[[redirects]]
+  force = true
+  from = "docs/getting-started/policies/index.html"
+  status = 301
+  to = "https://doc.biscuitsec.org/getting-started/authorization-policies.html"
+
+[[redirects]]
+  force = true
+  from = "/docs/getting-started/datalog/"
+  status = 301
+  to = "https://doc.biscuitsec.org/getting-started/authorization-policies.html"
+
+[[redirects]]
+  force = true
+  from = "docs/getting-started/datalog/index.html"
+  status = 301
+  to = "https://doc.biscuitsec.org/getting-started/authorization-policies.html"
+
+[[redirects]]
+  force = true
+  from = "/docs/Usage/c/"
+  status = 301
+  to = "https://doc.biscuitsec.org/usage/c.html"
+
+[[redirects]]
+  force = true
+  from = "docs/Usage/c/index.html"
+  status = 301
+  to = "https://doc.biscuitsec.org/usage/c.html"
+
+[[redirects]]
+  force = true
+  from = "/docs/Usage/go/"
+  status = 301
+  to = "https://doc.biscuitsec.org/usage/go.html"
+
+[[redirects]]
+  force = true
+  from = "docs/Usage/go/index.html"
+  status = 301
+  to = "https://doc.biscuitsec.org/usage/go.html"
+
+[[redirects]]
+  force = true
+  from = "/docs/Usage/node/"
+  status = 301
+  to = "https://doc.biscuitsec.org/usage/nodejs.html"
+
+[[redirects]]
+  force = true
+  from = "docs/Usage/node/index.html"
+  status = 301
+  to = "https://doc.biscuitsec.org/usage/nodejs.html"
+
+[[redirects]]
+  force = true
+  from = "/docs/Usage/cli/"
+  status = 301
+  to = "https://doc.biscuitsec.org/usage/command-line.html"
+
+[[redirects]]
+  force = true
+  from = "docs/Usage/cli/index.html"
+  status = 301
+  to = "https://doc.biscuitsec.org/usage/command-line.html"
+
+[[redirects]]
+  force = true
+  from = "/docs/Usage/haskell/"
+  status = 301
+  to = "https://doc.biscuitsec.org/usage/haskell.html"
+
+[[redirects]]
+  force = true
+  from = "docs/Usage/haskell/index.html"
+  status = 301
+  to = "https://doc.biscuitsec.org/usage/haskell.html"
+
+[[redirects]]
+  force = true
+  from = "/docs/Usage/java/"
+  status = 301
+  to = "https://doc.biscuitsec.org/usage/java.html"
+
+[[redirects]]
+  force = true
+  from = "docs/Usage/java/index.html"
+  status = 301
+  to = "https://doc.biscuitsec.org/usage/java.html"
+
+[[redirects]]
+  force = true
+  from = "/docs/Usage/rust/"
+  status = 301
+  to = "https://doc.biscuitsec.org/usage/rust.html"
+
+[[redirects]]
+  force = true
+  from = "docs/Usage/rust/index.html"
+  status = 301
+  to = "https://doc.biscuitsec.org/usage/rust.html"
+
+[[redirects]]
+  force = true
+  from = "/docs/guides/common-patterns/"
+  status = 301
+  to = "https://doc.biscuitsec.org/recipes/common-patterns.html"
+
+[[redirects]]
+  force = true
+  from = "docs/guides/common-patterns/index.html"
+  status = 301
+  to = "https://doc.biscuitsec.org/recipes/common-patterns.html"
+
+[[redirects]]
+  force = true
+  from = "/docs/guides/interop/"
+  status = 301
+  to = "https://doc.biscuitsec.org/recipes/interoperability-reusability.html"
+
+[[redirects]]
+  force = true
+  from = "docs/guides/interop/index.html"
+  status = 301
+  to = "https://doc.biscuitsec.org/recipes/interoperability-reusability.html"
+
+[[redirects]]
+  force = true
+  from = "/docs/guides/rbac/"
+  status = 301
+  to = "https://doc.biscuitsec.org/recipes/role-based-access-control.html"
+
+[[redirects]]
+  force = true
+  from = "docs/guides/rbac/index.html"
+  status = 301
+  to = "https://doc.biscuitsec.org/recipes/role-based-access-control.html"
+
+[[redirects]]
+  force = true
+  from = "/docs/reference/cryptography/"
+  status = 301
+  to = "https://doc.biscuitsec.org/reference/cryptography.html"
+
+[[redirects]]
+  force = true
+  from = "docs/reference/cryptography/index.html"
+  status = 301
+  to = "https://doc.biscuitsec.org/reference/cryptography.html"
+
+[[redirects]]
+  force = true
+  from = "/docs/reference/datalog/"
+  status = 301
+  to = "https://doc.biscuitsec.org/reference/datalog.html"
+
+[[redirects]]
+  force = true
+  from = "docs/reference/datalog/index.html"
+  status = 301
+  to = "https://doc.biscuitsec.org/reference/datalog.html"
+

--- a/redirects.dhall
+++ b/redirects.dhall
@@ -1,0 +1,89 @@
+let concatMap =
+      https://prelude.dhall-lang.org/List/concatMap
+        sha256:3b2167061d11fda1e4f6de0522cbe83e0d5ac4ef5ddf6bb0b2064470c5d3fb64
+
+let Entry = { from : Text, to : Text, status : Natural, force : Bool }
+
+let Conf = { oldPrefix : Text, newPrefix : Text }
+
+let Mapping = { old : Text, new : Text }
+
+let mkEntry =
+      \(c : Conf) ->
+      \(e : Mapping) ->
+        [ { from = "/docs/${c.oldPrefix}/${e.old}/"
+          , to = "https://doc.biscuitsec.org/${c.newPrefix}/${e.new}.html"
+          , status = 301
+          , force = True
+          }
+        , { from = "docs/${c.oldPrefix}/${e.old}/index.html"
+          , to = "https://doc.biscuitsec.org/${c.newPrefix}/${e.new}.html"
+          , status = 301
+          , force = True
+          }
+        ]
+
+let mkSectionEntry =
+      \(e : Mapping) ->
+        [ { from = "/docs/${e.old}"
+          , to = "https://doc.biscuitsec.org/${e.new}.html"
+          , status = 301
+          , force = True
+          }
+        , { from = "docs/${e.old}/index.html"
+          , to = "https://doc.biscuitsec.org/${e.new}.html"
+          , status = 301
+          , force = True
+          }
+        ]
+
+let gettingStarted =
+      concatMap
+        Mapping
+        Entry
+        ( mkEntry
+            { oldPrefix = "getting-started", newPrefix = "getting-started" }
+        )
+        [ { old = "introduction", new = "introduction" }
+        , { old = "token", new = "introduction" }
+        , { old = "my-first-biscuit", new = "my-first-biscuit" }
+        , { old = "policies", new = "authorization-policies" }
+        , { old = "datalog", new = "authorization-policies" }
+        ]
+
+let usage =
+      concatMap
+        Mapping
+        Entry
+        (mkEntry { oldPrefix = "Usage", newPrefix = "usage" })
+        [ { old = "c", new = "c" }
+        , { old = "go", new = "go" }
+        , { old = "node", new = "nodejs" }
+        , { old = "cli", new = "command-line" }
+        , { old = "haskell", new = "haskell" }
+        , { old = "java", new = "java" }
+        , { old = "rust", new = "rust" }
+        ]
+
+let recipes =
+      concatMap
+        Mapping
+        Entry
+        (mkEntry { oldPrefix = "guides", newPrefix = "recipes" })
+        [ { old = "common-patterns", new = "common-patterns" }
+        , { old = "interop", new = "interoperability-reusability" }
+        , { old = "rbac", new = "role-based-access-control" }
+        ]
+
+let reference =
+      concatMap
+        Text
+        Entry
+        ( \(t : Text) ->
+            mkEntry
+              { oldPrefix = "reference", newPrefix = "reference" }
+              { old = t, new = t }
+        )
+        [ "cryptography", "datalog" ]
+
+in  { redirects = gettingStarted # usage # recipes # reference }

--- a/templates/macros/footer.html
+++ b/templates/macros/footer.html
@@ -7,7 +7,7 @@
 					{% if config.extra.footer.info %}
 						<li class="list-inline-item">{{ config.extra.footer.info | default(value="Powered by AdiDoks") | safe }}</li>
 					{% else %}
-						<li class="list-inline-item">Proudly hosted by <a href="https://www.clever-cloud.com/">Clever Cloud</a>, <a href="https://www.getzola.org/">Zola</a>, and <a href="https://github.com/aaranxu/adidoks">AdiDoks</a>, domain name donated by <a href="https://twitter.com/fimbault">Fabien Imbault</a>
+						<li class="list-inline-item">Powered by <a href="https://www.netlify.com/">Netlify</a>,  <a href="https://www.getzola.org/">Zola</a>, and <a href="https://github.com/aaranxu/adidoks">AdiDoks</a>, domain name donated by <a href="https://twitter.com/fimbault">Fabien Imbault</a>
  </li>
 
 					{% endif %}

--- a/templates/macros/header.html
+++ b/templates/macros/header.html
@@ -31,7 +31,7 @@
 					{% endfor %}
 				{% else %}
 				<li class="nav-item">
-					<a class="nav-link" href="{{ get_url(path="docs/getting-started/introduction/", trailing_slash=true) | safe }}">Docs</a>
+					<a class="nav-link" href="https://doc.biscuitsec.org">Docs</a>
 				</li>
 				<li class="nav-item">
 					<a class="nav-link" href="{{ get_url(path="blog", trailing_slash=true) | safe }}">Blog</a>


### PR DESCRIPTION
Migrating documentation pages requires setting up HTTP redirects to avoid breaking existing link.
Sadly, the current hosting provider, Clever Cloud, does not support redirects on its static hosting offer.

This PR deploys both biscuitsec.org and doc.biscuitsec.org to netlify, which does support redirects.

This PR is not mergeable yet, as it requires external DNS configuration.