### PR TITLE
doc: use playgrounds where it makes sense

### DIFF
--- a/docs/src/getting-started/authorization-policies.md
+++ b/docs/src/getting-started/authorization-policies.md
@@ -56,7 +56,6 @@ allow if
   resource($res),
   operation($op),
   right($res, $op);
-
 // otherwise, allow if we're admin
 allow if is_admin();
 </code></pre>

--- a/docs/src/getting-started/introduction.md
+++ b/docs/src/getting-started/introduction.md
@@ -35,23 +35,18 @@ Those authorization policies can be hardcoded in your application or be dynamica
 
 ### Authorization policy example
 
-Authorizer
-
-<bc-datalog-editor>
-<pre><code>
+<bc-datalog-playground>
+<pre><code class="authorizer">
 // We receive a request to read "admin.doc"
 // The request contains a token with the following content
 user("1234"); // the user is identified as "1234"
 check if operation("read"); // the token is restricted to read-only operations
-
 // The authorizer loads facts representing the request
 resource("admin.doc");
 operation("read");
-
 // The authorizer loads the user's rights
 right("1234", "admin.doc", "read");
 right("1234", "admin.doc", "write");
-
 // Finally, the authorizer tests policies
 // by looking for a set of facts matching them
 allow if
@@ -60,26 +55,7 @@ allow if
   operation($op),
   right($user_id, $res, $op);
 </code></pre>
-</bc-datalog-editor> 
-
-Result
-
-**Success**
-
-Facts
-
-<bc-datalog-editor>
-<pre><code>
-operation("read");
-
-resource("admin.doc");
-
-right("1234","admin.doc","read");
-right("1234","admin.doc","write");
-
-user("1234");
-</code></pre>
-</bc-datalog-editor> 
+</bc-datalog-playground> 
 
 ## Biscuit is so much more
 

--- a/docs/src/getting-started/my-first-biscuit.md
+++ b/docs/src/getting-started/my-first-biscuit.md
@@ -91,7 +91,6 @@ _authorizer.biscuit-datalog_
 operation("write");
 resource("resource1");
 time(2021-12-21T20:00:00Z);
-
 // server-side ACLs
 right("1234", "resource1", "read");
 right("1234", "resource1", "write");
@@ -101,7 +100,6 @@ is_allowed($user, $res, $op) <-
   resource($res),
   operation($op),
   right($user, $res, $op);
-
 // the request can go through if the current user
 // is allowed to perform the current operation
 // on the current resource

--- a/docs/src/recipes/role-based-access-control.md
+++ b/docs/src/recipes/role-based-access-control.md
@@ -36,8 +36,8 @@ We want to check if an operation is authorized, depending on the user requesting
 
 From that user id, we would look up in the database the user's roles, and for each role the authorized operations, and load that as facts. We can then check that we have the rights to perform the operation:
 
-<bc-datalog-editor>
-<pre><code>
+<bc-datalog-playground>
+<pre><code class="authorizer">
 role("admin", ["billing:read", "billing:write", "address:read", "address:write"] );
 role("accounting", ["billing:read", "billing:write", "address:read"]);
 role("support", ["address:read", "address:write"]);
@@ -70,7 +70,7 @@ allow if
 
 deny if true;
 </code></pre>
-</bc-datalog-editor> 
+</bc-datalog-playground> 
 
 Why are we loading data from the database and checking the rights here, while we could do all of that as part of a SQL query? After all, Datalog is doing similar work, joining facts like we would join tables.
 
@@ -168,8 +168,8 @@ right($id, $principal, $operation, $priority) <-
 
 You can explore the full example here:
 
-<bc-datalog-editor>
-<pre><code>
+<bc-datalog-playground>
+<pre><code class="authorizer">
 role("low priority", "admin", ["billing:read", "billing:write", "address:read", "address:write"] );
 role("low priority","accounting", ["billing:read", "billing:write", "address:read"]);
 role("low priority","support", ["address:read", "address:write"]);
@@ -214,7 +214,7 @@ allow if
 
 deny if true;
 </code></pre>
-</bc-datalog-editor> 
+</bc-datalog-playground> 
 
 ## Attenuation
 
@@ -224,8 +224,8 @@ Attenuation in Biscuit provides a good escape hatch to avoid that complexity. As
 
 Leela can instead take her own token, attenuate it to allow the delivery of high priority packages for a limited time. She can even seal the token to avoid other attenuations. We would end up with the following:
 
-<bc-datalog-editor>
-<pre><code>
+<bc-datalog-playground>
+<pre><code class="authorizer">
 // we got this from the first block of the token
 user(3);
 
@@ -269,6 +269,6 @@ allow if
 
 deny if true
 </code></pre>
-</bc-datalog-editor> 
+</bc-datalog-playground> 
 
 Attenuating a token does not increase rights: if suddenly Leela loses the delivery role, the check of the attenuated token could succeed but authorization would fail both for Leela and Bender because the `right` fact would not be generated.


### PR DESCRIPTION
Instead of just displaying datalog snippets, using the playground makes sense, since it will evaluate datalog and display generated facts, as well as checks and policies results.