### PR TITLE
Python docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -18,6 +18,7 @@
     - [Haskell](usage/haskell.md)
     - [Java](usage/java.md)
     - [NodeJS](usage/nodejs.md)
+    - [Python](usage/python.md)
     - [Rust](usage/rust.md)
     - [Web components](usage/web-components.md)
 

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -8,3 +8,4 @@
 - [NodeJS](./usage/nodejs.md)
 - [Python](./usage/python.md)
 - [Rust](./usage/rust.md)
+- [Web components](./usage/web-components.md)

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -6,4 +6,5 @@
 - [Haskell](./usage/haskell.md)
 - [Java](./usage/java.md)
 - [NodeJS](./usage/nodejs.md)
+- [Python](./usage/python.md)
 - [Rust](./usage/rust.md)

--- a/docs/src/usage/python.md
+++ b/docs/src/usage/python.md
@@ -1,0 +1,5 @@
+# Python
+
+Python bindings for Biscuit are distributed on [PyPI](https://pypi.org/project/biscuit-python). They wrap the [Biscuit Rust library](https://github.com/biscuit-auth/biscuit-rust), and provide a pythonic API.
+
+Detailed documentation is available at <https://biscuit-python.netlify.app>.


### PR DESCRIPTION
Now that `biscuit-python` is published to pypi and has a proper documentation website, we can add it to <https://doc.biscuitsec.org>.