### PR TITLE
Fix node.js examples

### DIFF
--- a/docs/src/usage/nodejs.md
+++ b/docs/src/usage/nodejs.md
@@ -44,20 +44,20 @@ const root = new KeyPair();
 ```javascript
 const { biscuit, KeyPair } = require('@biscuit-auth/biscuit-wasm');
 
-const root = new KeyPair();
 const userId = "1234";
 // a token can be created from a datalog snippet
-const biscuitBuilder = biscuit`
+const builder = biscuit`
   user(${userId});
   check if resource("file1");
 `;
 
 // facts, checks and rules can be added one by one on an existing builder.
 for (let right of ["read", "write"]) {
-    biscuitBuilder.addFact(fact`right(${right})`);
+    builder.addFact(fact`right(${right})`);
 }
 
-const token = builder.build(root);
+const privateKey = PrivateKey.fromString("<private key">);
+const token = builder.build(privateKey);
 console.log(token.toBase64());
 ```
 
@@ -66,7 +66,8 @@ console.log(token.toBase64());
 ```javascript
 const { authorizer, Biscuit } = require('@biscuit-auth/biscuit-wasm');
 
-const token = Biscuit.fromBase64("<base64 string>");
+const publicKey = PublicKey.fromString("<public key">);
+const token = Biscuit.fromBase64("<base64 string>", publicKey);
 
 const userId = "1234";
 const auth = authorizer`
@@ -93,7 +94,8 @@ const acceptedPolicyCustomLimits = authorizer.authorizeWithLimits({
 ```javascript
 const { block, Biscuit } = require('@biscuit-auth/biscuit-wasm');
 
-const token = Biscuit.fromBase64("<base64 string>");
+const publicKey = PublicKey.fromString("<public key">);
+const token = Biscuit.fromBase64("<base64 string>", publicKey);
 
 // restrict to read only
 const attenuatedToken = token.append(block`check if operation("read")`);
@@ -107,7 +109,8 @@ A sealed token cannot be attenuated further.
 ```javascript
 const { Biscuit } = require('@biscuit-auth/biscuit-wasm');
 
-const token = Biscuit.fromBase64("<base64 string>");
+const publicKey = PublicKey.fromString("<public key">);
+const token = Biscuit.fromBase64("<base64 string>", publicKey);
 
 const sealedToken = token.sealToken();
 ```
@@ -118,7 +121,8 @@ const sealedToken = token.sealToken();
 ```javascript
 const { Biscuit } = require('@biscuit-auth/biscuit-wasm');
 
-const token = Biscuit.fromBase64("<base64 string>");
+const publicKey = PublicKey.fromString("<public key">);
+const token = Biscuit.fromBase64("<base64 string>", publicKey);
 
 // revocationIds is a list of hex-encoded revocation identifiers,
 // one per block

--- a/docs/src/usage/nodejs.md
+++ b/docs/src/usage/nodejs.md
@@ -42,7 +42,7 @@ const root = new KeyPair();
 ## Create a token
 
 ```javascript
-const { biscuit, KeyPair } = require('@biscuit-auth/biscuit-wasm');
+const { biscuit, PrivateKey } = require('@biscuit-auth/biscuit-wasm');
 
 const userId = "1234";
 // a token can be created from a datalog snippet
@@ -56,7 +56,7 @@ for (let right of ["read", "write"]) {
     builder.addFact(fact`right(${right})`);
 }
 
-const privateKey = PrivateKey.fromString("<private key">);
+const privateKey = PrivateKey.fromString("<private key>");
 const token = builder.build(privateKey);
 console.log(token.toBase64());
 ```
@@ -64,9 +64,9 @@ console.log(token.toBase64());
 ## Authorize a token
 
 ```javascript
-const { authorizer, Biscuit } = require('@biscuit-auth/biscuit-wasm');
+const { authorizer, Biscuit, PublicKey } = require('@biscuit-auth/biscuit-wasm');
 
-const publicKey = PublicKey.fromString("<public key">);
+const publicKey = PublicKey.fromString("<public key>");
 const token = Biscuit.fromBase64("<base64 string>", publicKey);
 
 const userId = "1234";
@@ -92,9 +92,9 @@ const acceptedPolicyCustomLimits = authorizer.authorizeWithLimits({
 ## Attenuate a token
 
 ```javascript
-const { block, Biscuit } = require('@biscuit-auth/biscuit-wasm');
+const { block, Biscuit, PublicKey } = require('@biscuit-auth/biscuit-wasm');
 
-const publicKey = PublicKey.fromString("<public key">);
+const publicKey = PublicKey.fromString("<public key>");
 const token = Biscuit.fromBase64("<base64 string>", publicKey);
 
 // restrict to read only
@@ -107,9 +107,9 @@ console.log(attenuatedToken.toBase64());
 A sealed token cannot be attenuated further.
 
 ```javascript
-const { Biscuit } = require('@biscuit-auth/biscuit-wasm');
+const { Biscuit, PublicKey } = require('@biscuit-auth/biscuit-wasm');
 
-const publicKey = PublicKey.fromString("<public key">);
+const publicKey = PublicKey.fromString("<public key>");
 const token = Biscuit.fromBase64("<base64 string>", publicKey);
 
 const sealedToken = token.sealToken();
@@ -119,9 +119,9 @@ const sealedToken = token.sealToken();
 
 
 ```javascript
-const { Biscuit } = require('@biscuit-auth/biscuit-wasm');
+const { Biscuit, PublicKey } = require('@biscuit-auth/biscuit-wasm');
 
-const publicKey = PublicKey.fromString("<public key">);
+const publicKey = PublicKey.fromString("<public key>");
 const token = Biscuit.fromBase64("<base64 string>", publicKey);
 
 // revocationIds is a list of hex-encoded revocation identifiers,
@@ -137,9 +137,10 @@ if (containsRevokedIds(revocationIds)) {
 ## Query data from the authorizer
 
 ```javascript
-const { authorizer, rule, Biscuit } = require('@biscuit-auth/biscuit-wasm');
+const { authorizer, rule, Biscuit, PublicKey } = require('@biscuit-auth/biscuit-wasm');
 
-const token = Biscuit.fromBase64("<base64 string>");
+const publicKey = PublicKey.fromString("<public key>");
+const token = Biscuit.fromBase64("<base64 string>", publicKey);
 
 const userId = "1234";
 const auth = authorizer`


### PR DESCRIPTION
# Description

This PR fixes, I think, a couple of issues in the nodejs examples (hosted at https://doc.biscuitsec.org/usage/nodejs).

Namely:
- The [Create a token](https://doc.biscuitsec.org/usage/nodejs#create-a-token) example defines a builder called `biscuitBuilder` but then calls `builder.build(...)`. I have changed all instances to just be called `builder`
- In the same example the generated keypair `root` is passed `builder.build(root)`. It seems it needs to be specifically the private key that is passed so I have:
    - removed `const root = new KeyPair()`
    - added a `const privateKey = PrivateKey.fromString("<private key>");`
    - called `builder.build(privateKey)`
- The other examples are calling `Biscuit.fromBase64("<base64 string>")`, but it seems this in reality also takes the root public key, so I have:
    - changed all instances to `const token = Biscuit.fromBase64("<base64 string>", publicKey);`
    - added a `const publicKey = PublicKey.fromString("<public key>");` above
- Appropriately updated the imports