### PR TITLE
add a contributors page

### DIFF
--- a/content/docs/contributors.md
+++ b/content/docs/contributors.md
@@ -1,0 +1,38 @@
++++
+title = "Biscuit contributors"
+description = "Individuals and companies contributing to biscuit"
+date = 2023-10-26T19:30:00+00:00
+updated = 2023-10-26T19:30:00+00:00
+draft = false
+weight = 30
+sort_by = "weight"
+template = "docs/page.html"
+
+[extra]
+toc = true
+top = false
++++
+
+Biscuit is provided as a spec and a series of libraries, all open-source. Some contributions are done on free time, some as part as paid work.
+
+If you manage or work for a company that has a vested interest in biscuit, you should contact the biscuit team to discuss sponsoring opportunities.
+
+## Core team
+
+### Geoffroy Couprie
+
+Geoffroy is in charge of the biscuit spec and the reference implementation, biscuit-rust. He contributes regularly to biscuit-wasm and the web-based tooling.
+
+### Clément Delafargue
+
+Clément co-authors the spec, contributes regularly to biscuit-rust, and is in charge of various bindings (wasm, python, web tooling), as well as biscuit-haskell and the CLI tooling.
+
+## Corporate sponsors
+
+### Clever Cloud
+
+Clever Cloud has kickstarted and sponsored the early development of biscuit (v0 and v1), when Geoffroy Couprie worked there. They are now in charge of biscuit-java.
+
+### Outscale
+
+Outscale is now the main corporate sponsor for biscuit by allocating a sizeable part of Clément Delafargue's schedule to biscuit.


### PR DESCRIPTION
The goal is to outline the areas covered by the main ICs, as well as what corporate sponsors actually do