### PR TITLE
Remove MdBook integrated playground

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -4,3 +4,6 @@ language = "en"
 multilingual = false
 src = "src"
 title = "Biscuit"
+
+[output.html.playground]
+runnable = false


### PR DESCRIPTION
As long the MdBook integrated playground (for Rust code) doesn't allow to import external crates, the Biscuit rust code example can't be run.
Then I think it's better to deactivate the "play" button.